### PR TITLE
fix: cakes protection

### DIFF
--- a/src/main/java/org/ayosynk/landClaimPlugin/listeners/protections/InteractProtectionListener.java
+++ b/src/main/java/org/ayosynk/landClaimPlugin/listeners/protections/InteractProtectionListener.java
@@ -66,6 +66,13 @@ public class InteractProtectionListener implements Listener {
             }
         }
 
+        if (event.getAction().isRightClick()) {
+            if(block != null && block.getType() == org.bukkit.Material.CAKE) {
+                checkPermission(event.getPlayer(), block, event, "BLOCK_BREAK");
+                return;
+            }
+        }
+
         if (block == null)
             return;
 


### PR DESCRIPTION
It checks if the player can break blocks. It seemed the most appropriate permission to me.